### PR TITLE
Fix: Removed non-existent columns from subscriptions query to resolve…

### DIFF
--- a/app/Http/Controllers/AdminSubscriptionController.php
+++ b/app/Http/Controllers/AdminSubscriptionController.php
@@ -24,20 +24,17 @@ class AdminSubscriptionController extends Controller
     public function index(Request $request)
     {
         if ($request->ajax()) {
+            // إزالة الأعمدة غير الموجودة في جدول subscriptions
             $query = Subscription::query()->select(
                 'id',
-                'user_name',
-                'subscription_id',
-                'status',
-                'start_date',
-                'next_billing_time',
-                'payment_status',
                 'product_name',
                 'description',
                 'price',
                 'subscription_type',
                 'features',
                 'is_active'
+                // يمكنك إضافة أي عمود آخر موجود فعليًا في جدول subscriptions هنا
+                // مثال: 'next_billing_time' لو أردت عرضه أو استخدامه
             );
 
             return DataTables::of($query)
@@ -81,7 +78,7 @@ class AdminSubscriptionController extends Controller
             'price'             => 'required|numeric|min:0',
             'features'          => 'nullable|string',
             'subscription_type' => 'required|string|in:yolo,solo,tolo',
-            'is_active'         => 'required|in:0,1', 
+            'is_active'         => 'required|in:0,1',
         ]);
 
         $featuresArray = $this->processFeatures($request->features);

--- a/resources/views/dashboard/admin/subscriptions/index.blade.php
+++ b/resources/views/dashboard/admin/subscriptions/index.blade.php
@@ -161,11 +161,9 @@
                 { data: 'description',        name: 'description' },
                 { data: 'price',              name: 'price' },
                 { data: 'subscription_type',  name: 'subscription_type' },
-                { 
+                {
                     data: 'is_active',
                     name: 'is_active',
-                    // ملاحظة: سننشئ الـcheckbox HTML في الـController (editColumn)
-                    // لذلك لن نضع render هنا (تكفي 'is_active' من الـController)
                 },
                 {
                     data: null,
@@ -187,7 +185,7 @@
                 { extend: 'pdf',   className: 'btn btn-outline-secondary' },
                 { extend: 'print', className: 'btn btn-outline-secondary' }
             ],
-            order: [[0, 'asc']], 
+            order: [[0, 'asc']],
             lengthChange: false
         });
 
@@ -254,8 +252,8 @@
             var subscriptionId = $('#edit_id').val();
             $.ajax({
                 url: '/admin/subscriptions/' + subscriptionId,
-                method: 'POST', 
-                data: $(this).serialize(), 
+                method: 'POST', // نظرًا لاستخدامنا hidden input: _method=PUT
+                data: $(this).serialize(),
                 success: function(response) {
                     $('#editSubscriptionModal').modal('hide');
                     Swal.fire('Success!', response.success, 'success');


### PR DESCRIPTION
## Description
This pull request fixes an SQL error in the subscriptions table query by removing non-existent columns.

## Changes
- Removed `user_name`, `subscription_id`, `status`, `start_date`, and `payment_status` from `AdminSubscriptionController@index`.
- Ensured only valid columns are selected.

## Related Issue
Closes #42
